### PR TITLE
Bumped to 4.7.2, added gamepath selection in launcher, ui fixes, crash fixes, admin rights

### DIFF
--- a/Launcher/ConfigProvider.cs
+++ b/Launcher/ConfigProvider.cs
@@ -21,6 +21,7 @@ namespace Launcher
         public string IpPort { get; set; } = string.Empty;
         public string SerialKey { get; set; } = string.Empty;
         public string Language { get; set; } = "en";
+        public string GamePath { get; set; } = string.Empty;
 
         private string _filePath;
 

--- a/Launcher/Launcher.cs
+++ b/Launcher/Launcher.cs
@@ -14,30 +14,45 @@ namespace Launcher
 
         public LaunchResult LaunchAndInject(string gamePath, string playerNickName, string serverIpAddress, ushort serverPort, string id, string serial, params string[] librariesToInject)
         {
-            if(!File.Exists(gamePath)) 
-                return LaunchResult.GameNotFound;
-
-            Process process = new Process();
-
-            process.StartInfo = new ProcessStartInfo()
+            try
             {
-                FileName = gamePath,
-                Arguments = $"-name {playerNickName} -ip {serverIpAddress} -port {serverPort} -id {id} -serial {serial}",
-                UseShellExecute = true
-            };
+                // Sometimes when you wish to inject and have dead gta process it will write inject error when in reality the issue is dead gta process.
+                Process[] processes = Process.GetProcessesByName("gta_sa");
+                for (int i = 0; i < processes.Length; i++)
+                {
+                    processes[i].Kill();
+                }
 
-            if(!process.Start())
-                return LaunchResult.LaunchFailed;
+                if (!File.Exists(gamePath))
+                    return LaunchResult.GameNotFound;
 
-            DllInjector dllInjector = new DllInjector(process);
+                Process process = new Process();
 
-            foreach (string library in librariesToInject)
-            {
-                if(dllInjector.Inject(AppDomain.CurrentDomain.BaseDirectory + library) != DllInjectionResult.Success)
-                    return LaunchResult.InjectionFailed;
+                process.StartInfo = new ProcessStartInfo()
+                {
+                    FileName = gamePath,
+                    Arguments = $"-name {playerNickName} -ip {serverIpAddress} -port {serverPort} -id {id} -serial {serial}",
+                    UseShellExecute = true
+                };
+
+                if (!process.Start())
+                    return LaunchResult.LaunchFailed;
+
+                DllInjector dllInjector = new DllInjector(process);
+
+                foreach (string library in librariesToInject)
+                {
+                    if (dllInjector.Inject(Path.Combine(Path.GetDirectoryName(gamePath), library)) != DllInjectionResult.Success)
+                        return LaunchResult.InjectionFailed;
+                }
+
+                return LaunchResult.Success;
             }
-
-            return LaunchResult.Success;
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error during launch and inject: {ex.Message}");
+                return LaunchResult.LaunchFailed;
+            }
         }
     }
 }

--- a/Launcher/Launcher.csproj
+++ b/Launcher/Launcher.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>Launcher</RootNamespace>
     <AssemblyName>Launcher</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
@@ -34,6 +34,9 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -79,6 +82,7 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <None Include="app.config" />
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Launcher/Localization.cs
+++ b/Launcher/Localization.cs
@@ -35,6 +35,7 @@ into any channel");
             en.Add(Program.MainForm.lb_serialkey, "Serial key:");
             en.Add(Program.MainForm.b_copy, "Copy");
             en.Add(Program.MainForm.link_discord, "Discord Server");
+            en.Add(Program.MainForm.lb_gtapath, "GTA SA Path:");
 
             ru.Add(Program.MainForm.b_connect, "Подключиться");
             ru.Add(Program.MainForm.lb_connect, "Подключиться к серверу CoopAndreas");
@@ -57,6 +58,7 @@ into any channel");
             ru.Add(Program.MainForm.lb_serialkey, "Серийный ключ:");
             ru.Add(Program.MainForm.b_copy, "Копировать");
             ru.Add(Program.MainForm.link_discord, "Discord Сервер");
+            ru.Add(Program.MainForm.lb_gtapath, "Путь к GTA SA:");
 
             pt.Add(Program.MainForm.b_connect, "Conectar");
             pt.Add(Program.MainForm.lb_connect, "Conectar a um servidor CoopAndreas"); 
@@ -80,6 +82,7 @@ qualquer canalе");
             pt.Add(Program.MainForm.lb_serialkey, "Chave serial:");
             pt.Add(Program.MainForm.b_copy, "Cópia");
             pt.Add(Program.MainForm.link_discord, "Discord Servidor");
+            pt.Add(Program.MainForm.lb_gtapath, "Caminho do GTA SA:");
 
             ua.Add(Program.MainForm.b_connect, "Підключитися");
             ua.Add(Program.MainForm.lb_connect, "Підключитися до сервера CoopAndreas");
@@ -102,6 +105,7 @@ qualquer canalе");
             ua.Add(Program.MainForm.lb_serialkey, "Серійний ключ");
             ua.Add(Program.MainForm.b_copy, "Копіювати");
             ua.Add(Program.MainForm.link_discord, "Discord Сервер");
+            ua.Add(Program.MainForm.lb_gtapath, "Шлях до GTA SA:");
 
             Dictionary.Add("en", en);
             Dictionary.Add("ru", ru);

--- a/Launcher/MainForm.Designer.cs
+++ b/Launcher/MainForm.Designer.cs
@@ -44,6 +44,7 @@
             this.nicknameInput = new System.Windows.Forms.TextBox();
             this.lb_nickname = new System.Windows.Forms.Label();
             this.serverPage = new System.Windows.Forms.TabPage();
+            this.label1 = new System.Windows.Forms.Label();
             this.b_startserver = new System.Windows.Forms.Button();
             this.lb_startserver = new System.Windows.Forms.Label();
             this.maxplayersInput = new System.Windows.Forms.NumericUpDown();
@@ -51,9 +52,11 @@
             this.lb_maxplayers = new System.Windows.Forms.Label();
             this.lb_port = new System.Windows.Forms.Label();
             this.configPage = new System.Windows.Forms.TabPage();
+            this.selectPathButton = new System.Windows.Forms.Button();
+            this.gtaPathInput = new System.Windows.Forms.TextBox();
+            this.lb_gtapath = new System.Windows.Forms.Label();
             this.languageCombo = new System.Windows.Forms.ComboBox();
             this.lb_language = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.connectPage.SuspendLayout();
             this.serverPage.SuspendLayout();
@@ -96,9 +99,9 @@
             // 
             // b_copy
             // 
-            this.b_copy.Location = new System.Drawing.Point(135, 204);
+            this.b_copy.Location = new System.Drawing.Point(161, 190);
             this.b_copy.Name = "b_copy";
-            this.b_copy.Size = new System.Drawing.Size(43, 23);
+            this.b_copy.Size = new System.Drawing.Size(118, 23);
             this.b_copy.TabIndex = 11;
             this.b_copy.Text = "Copy";
             this.b_copy.UseVisualStyleBackColor = true;
@@ -106,10 +109,10 @@
             // 
             // tb_command
             // 
-            this.tb_command.Location = new System.Drawing.Point(29, 204);
+            this.tb_command.Location = new System.Drawing.Point(29, 190);
             this.tb_command.Name = "tb_command";
             this.tb_command.ReadOnly = true;
-            this.tb_command.Size = new System.Drawing.Size(99, 20);
+            this.tb_command.Size = new System.Drawing.Size(126, 20);
             this.tb_command.TabIndex = 10;
             this.tb_command.Text = "Loading...";
             // 
@@ -117,7 +120,7 @@
             // 
             this.link_discord.AutoSize = true;
             this.link_discord.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.link_discord.Location = new System.Drawing.Point(184, 207);
+            this.link_discord.Location = new System.Drawing.Point(106, 216);
             this.link_discord.Name = "link_discord";
             this.link_discord.Size = new System.Drawing.Size(97, 16);
             this.link_discord.TabIndex = 9;
@@ -137,7 +140,7 @@
             // 
             // tb_serialKey
             // 
-            this.tb_serialKey.Location = new System.Drawing.Point(70, 89);
+            this.tb_serialKey.Location = new System.Drawing.Point(99, 89);
             this.tb_serialKey.Name = "tb_serialKey";
             this.tb_serialKey.Size = new System.Drawing.Size(180, 20);
             this.tb_serialKey.TabIndex = 7;
@@ -176,7 +179,7 @@
             // 
             // ipportInput
             // 
-            this.ipportInput.Location = new System.Drawing.Point(70, 63);
+            this.ipportInput.Location = new System.Drawing.Point(99, 59);
             this.ipportInput.Name = "ipportInput";
             this.ipportInput.Size = new System.Drawing.Size(180, 20);
             this.ipportInput.TabIndex = 3;
@@ -193,7 +196,7 @@
             // 
             // nicknameInput
             // 
-            this.nicknameInput.Location = new System.Drawing.Point(70, 36);
+            this.nicknameInput.Location = new System.Drawing.Point(99, 33);
             this.nicknameInput.Name = "nicknameInput";
             this.nicknameInput.Size = new System.Drawing.Size(180, 20);
             this.nicknameInput.TabIndex = 1;
@@ -224,6 +227,17 @@
             this.serverPage.Size = new System.Drawing.Size(311, 311);
             this.serverPage.TabIndex = 1;
             this.serverPage.Text = "Server";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.label1.Location = new System.Drawing.Point(26, 41);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(265, 96);
+            this.label1.TabIndex = 8;
+            this.label1.Text = "!!!\r\nTHIS TAB IS TEMPORARILY \r\nUNAVAILABLE, LAUNCH VIA \r\n`server.exe`";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // b_startserver
             // 
@@ -286,6 +300,9 @@
             // configPage
             // 
             this.configPage.BackColor = System.Drawing.Color.White;
+            this.configPage.Controls.Add(this.selectPathButton);
+            this.configPage.Controls.Add(this.gtaPathInput);
+            this.configPage.Controls.Add(this.lb_gtapath);
             this.configPage.Controls.Add(this.languageCombo);
             this.configPage.Controls.Add(this.lb_language);
             this.configPage.Location = new System.Drawing.Point(4, 22);
@@ -294,6 +311,36 @@
             this.configPage.Size = new System.Drawing.Size(311, 311);
             this.configPage.TabIndex = 2;
             this.configPage.Text = "Config";
+            // 
+            // selectPathButton
+            // 
+            this.selectPathButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.selectPathButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 6.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.selectPathButton.Location = new System.Drawing.Point(234, 47);
+            this.selectPathButton.Name = "selectPathButton";
+            this.selectPathButton.Size = new System.Drawing.Size(27, 20);
+            this.selectPathButton.TabIndex = 4;
+            this.selectPathButton.Text = "...";
+            this.selectPathButton.UseVisualStyleBackColor = true;
+            this.selectPathButton.Click += new System.EventHandler(this.selectPathButton_Click);
+            // 
+            // gtaPathInput
+            // 
+            this.gtaPathInput.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.gtaPathInput.Location = new System.Drawing.Point(101, 47);
+            this.gtaPathInput.Name = "gtaPathInput";
+            this.gtaPathInput.Size = new System.Drawing.Size(127, 20);
+            this.gtaPathInput.TabIndex = 3;
+            this.gtaPathInput.TextChanged += new System.EventHandler(this.gtaPathInput_TextChanged);
+            // 
+            // lb_gtapath
+            // 
+            this.lb_gtapath.AutoSize = true;
+            this.lb_gtapath.Location = new System.Drawing.Point(6, 50);
+            this.lb_gtapath.Name = "lb_gtapath";
+            this.lb_gtapath.Size = new System.Drawing.Size(74, 13);
+            this.lb_gtapath.TabIndex = 2;
+            this.lb_gtapath.Text = "GTA SA Path:";
             // 
             // languageCombo
             // 
@@ -312,22 +359,11 @@
             // lb_language
             // 
             this.lb_language.AutoSize = true;
-            this.lb_language.Location = new System.Drawing.Point(37, 14);
+            this.lb_language.Location = new System.Drawing.Point(6, 14);
             this.lb_language.Name = "lb_language";
             this.lb_language.Size = new System.Drawing.Size(58, 13);
             this.lb_language.TabIndex = 0;
             this.lb_language.Text = "Language:";
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
-            this.label1.Location = new System.Drawing.Point(26, 41);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(265, 96);
-            this.label1.TabIndex = 8;
-            this.label1.Text = "!!!\r\nTHIS TAB IS TEMPORARILY \r\nUNAVAILABLE, LAUNCH VIA \r\n`server.exe`";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // MainForm
             // 
@@ -337,6 +373,7 @@
             this.Controls.Add(this.tabControl1);
             this.MaximizeBox = false;
             this.Name = "MainForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "CoopAndreas Launcher";
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.tabControl1.ResumeLayout(false);
@@ -378,6 +415,9 @@
         public System.Windows.Forms.TextBox tb_command;
         public System.Windows.Forms.Button b_copy;
         private System.Windows.Forms.Label label1;
+        public System.Windows.Forms.Label lb_gtapath;
+        private System.Windows.Forms.TextBox gtaPathInput;
+        private System.Windows.Forms.Button selectPathButton;
     }
 }
 

--- a/Launcher/MainForm.cs
+++ b/Launcher/MainForm.cs
@@ -41,6 +41,7 @@ namespace Launcher
             nicknameInput.Text = config.NickName;
             ipportInput.Text = config.IpPort;
             tb_serialKey.Text = config.SerialKey;
+            gtaPathInput.Text = config.GamePath;
 
             var computerId = new ComputerID();
 
@@ -74,7 +75,7 @@ namespace Launcher
 
             Launcher launcher = new Launcher();
             
-            LaunchResult result = launcher.LaunchAndInject("gta_sa.exe", nicknameInput.Text, ip, port, tb_command.Text.Replace("/gen", "").Trim(), tb_serialKey.Text, launcher.LibrariesToInject);
+            LaunchResult result = launcher.LaunchAndInject(config.GamePath, nicknameInput.Text, ip, port, tb_command.Text.Replace("/gen", "").Trim(), tb_serialKey.Text, launcher.LibrariesToInject);
 
             if(result != LaunchResult.Success)
                 MessageBox.Show(result.ToString());
@@ -113,6 +114,26 @@ namespace Launcher
         private void b_copy_Click(object sender, EventArgs e)
         {
             Clipboard.SetText(tb_command.Text);
+        }
+
+        private void gtaPathInput_TextChanged(object sender, EventArgs e)
+        {
+            config.GamePath = gtaPathInput.Text;
+            config.Save();
+        }
+
+        private void selectPathButton_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog
+            {
+                Filter = "GTA SA Executable|gta_sa.exe",
+                Title = "Select GTA SA Executable",
+                InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+            };
+            if (openFileDialog.ShowDialog() == DialogResult.OK)
+            {
+                gtaPathInput.Text = openFileDialog.FileName;
+            }
         }
     }
 }

--- a/Launcher/Properties/Settings.Designer.cs
+++ b/Launcher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Launcher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Launcher/app.config
+++ b/Launcher/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/Launcher/app.manifest
+++ b/Launcher/app.manifest
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>


### PR DESCRIPTION
Modern Visual Studio 2022 doesn't support anymore .NET Framework 4.0.0, Also most of the launchers for Windows 7 uses 4.7.2 .NET Framework and it works fine with them.

Added ability to select game path instead of relying on putting the launcher.exe into the game folder. (You can write path or select using FileDialog)

<img width="346" height="394" alt="image" src="https://github.com/user-attachments/assets/a87e4bf6-d4f5-44a6-89b7-a2e4f51af9b9" />

UI Fixes (Localization and button placement is now better and more readable, also window appears on the center of screen rather than on top left):

<img width="346" height="394" alt="image" src="https://github.com/user-attachments/assets/a61173e0-e3cd-4ea0-9107-6c34593020bf" />

<img width="346" height="394" alt="image" src="https://github.com/user-attachments/assets/ccd9a28c-cc65-4a6c-a671-9546a5924784" />

Crash fix:

When you we're launching the game using launcher and you had dead gta process it would crash with error that dll was failed to inject. Killing all gta possible processes before starting resolves the issue.

Admin rights:

Now users will have to give admin permission right away to avoid most of the GTA related issues.