### PR TITLE
Fixed server compiling for Linux

### DIFF
--- a/server/src/CControllerState.h
+++ b/server/src/CControllerState.h
@@ -3,6 +3,8 @@
 #ifndef _CCONTROLLERSTATE_H_
     #define _CCONTROLLERSTATE_H_
 
+#include <cstdint>
+
 class CControllerState 
 {    
     public:

--- a/server/src/CNetwork.cpp
+++ b/server/src/CNetwork.cpp
@@ -4,6 +4,16 @@
 #include <vector>
 #include <algorithm>
 #include <unordered_map>
+#include <cstring>
+
+// Platform compatibility macros
+#if defined(_WIN32)
+	#define STR_COPY_S(dest, src) strcpy_s(dest, sizeof(dest), src)
+	#define STR_COPY_N_S(dest, src, count) strncpy_s(dest, sizeof(dest), src, count)
+#else
+	#define STR_COPY_S(dest, src) strncpy(dest, src, sizeof(dest) - 1); (dest)[sizeof(dest) - 1] = '\0'
+	#define STR_COPY_N_S(dest, src, count) strncpy(dest, src, count)
+#endif
 
 #include "CPacketListener.h"
 #include "CPacket.h"
@@ -285,7 +295,7 @@ void CNetwork::HandlePlayerConnected(ENetPeer* peer, void* data, int size)
 
     int freeId = CPlayerManager::GetFreeID();
     CPlayer* player = new CPlayer(peer, freeId);
-    strcpy_s(player->m_Name, packet->name);
+    STR_COPY_S(player->m_Name, packet->name);
     CPlayerManager::Add(player);
 
     uint32_t packedVersion = semver_parse(COOPANDREAS_VERSION, nullptr);
@@ -321,7 +331,7 @@ void CNetwork::HandlePlayerConnected(ENetPeer* peer, void* data, int size)
         CPlayerPackets::PlayerConnected newPlayerPacket{};
         newPlayerPacket.id = i->m_iPlayerId;
         newPlayerPacket.isAlreadyConnected = true;
-        strcpy_s(newPlayerPacket.name, i->m_Name);
+        STR_COPY_S(newPlayerPacket.name, i->m_Name);
 
         CNetwork::SendPacket(peer, CPacketsID::PLAYER_CONNECTED, &newPlayerPacket, sizeof(CPlayerPackets::PlayerConnected), ENET_PACKET_FLAG_RELIABLE);
 
@@ -402,7 +412,7 @@ void CNetwork::HandlePlayerConnected(ENetPeer* peer, void* data, int size)
         packet.pos = i->m_vecPos;
         packet.pedType = i->m_nPedType;
         packet.createdBy = i->m_nCreatedBy;
-        strncpy_s(packet.specialModelName, i->m_szSpecialModelName, strlen(i->m_szSpecialModelName));
+        STR_COPY_N_S(packet.specialModelName, i->m_szSpecialModelName, strlen(i->m_szSpecialModelName));
         CNetwork::SendPacket(peer, CPacketsID::PED_SPAWN, &packet, sizeof packet, ENET_PACKET_FLAG_RELIABLE);
     }
 

--- a/server/src/CPedManager.h
+++ b/server/src/CPedManager.h
@@ -8,6 +8,17 @@
 #include <vector>
 #include <algorithm>
 
+// Platform compatibility macros
+#if defined(_WIN32)
+	#define STR_CASE_CMP(s1, s2, n) _strnicmp(s1, s2, n)
+	#define STR_COPY_S(dest, src) strncpy_s(dest, sizeof(dest), src, _TRUNCATE)
+	#define STR_COPY_N_S(dest, src, count) strncpy_s(dest, sizeof(dest), src, count)
+#else
+	#define STR_CASE_CMP(s1, s2, n) strncasecmp(s1, s2, n)
+	#define STR_COPY_S(dest, src) strncpy(dest, src, sizeof(dest) - 1); (dest)[sizeof(dest) - 1] = '\0'
+	#define STR_COPY_N_S(dest, src, count) strncpy(dest, src, count)
+#endif
+
 #include "CPed.h"
 #include "CPlayerManager.h"
 #include "CVehicleManager.h"
@@ -68,7 +79,7 @@ class CPedPackets
 
 					for (int i = 0; i < 52; i++)
 					{
-						if (_strnicmp(packet->specialModelName, CPedManager::ms_aszAllowedSpecialActors[i], strlen(CPedManager::ms_aszAllowedSpecialActors[i])))
+						if (STR_CASE_CMP(packet->specialModelName, CPedManager::ms_aszAllowedSpecialActors[i], strlen(CPedManager::ms_aszAllowedSpecialActors[i])) == 0)
 						{
 							isSpecialModelValid = true;
 							break;
@@ -83,7 +94,7 @@ class CPedPackets
 				CNetwork::SendPacketToAll(CPacketsID::PED_SPAWN, packet, sizeof * packet, ENET_PACKET_FLAG_RELIABLE, peer);
 		
 				CPed* ped = new CPed(packet->pedid, player, packet->modelId, packet->pedType, packet->pos, packet->createdBy);
-				strncpy_s(ped->m_szSpecialModelName, packet->specialModelName, 7);
+				STR_COPY_N_S(ped->m_szSpecialModelName, packet->specialModelName, 7);
 				CPedManager::Add(ped);
 
 				// send it back to the syncer of the ped so that he knows the id
@@ -134,7 +145,7 @@ class CPedPackets
 						pedSpawnPacket.modelId = ped->m_nModelId;
 						pedSpawnPacket.pedType = ped->m_nPedType;
 						pedSpawnPacket.pos = ped->m_vecPos;
-						strncpy_s(pedSpawnPacket.specialModelName, sizeof(pedSpawnPacket.specialModelName), ped->m_szSpecialModelName, _TRUNCATE);
+						STR_COPY_N_S(pedSpawnPacket.specialModelName, ped->m_szSpecialModelName, strlen(ped->m_szSpecialModelName));
 						pedSpawnPacket.tempid = 0xFF;
 						pedSpawnPacket.createdBy = ped->m_nCreatedBy;
 						CNetwork::SendPacket(peer, CPacketsID::PED_SPAWN, &pedSpawnPacket, sizeof(pedSpawnPacket), ENET_PACKET_FLAG_RELIABLE);

--- a/xmake.lua
+++ b/xmake.lua
@@ -3,9 +3,14 @@ set_project("CoopAndreas")
 local force_msvc = true;
 
 set_languages("cxx17")
-set_arch("x86")
-set_plat("windows")
-set_toolchains("clang-cl") -- required to generate compile_commands.json properly
+
+if is_os("windows") then
+    set_arch("x86")
+    set_plat("windows")
+    set_toolchains("clang-cl") -- required to generate compile_commands.json properly
+elseif is_os("linux") then
+    set_plat("linux")
+end
 
 add_rules("plugin.compile_commands.autoupdate")
 add_rules("mode.debug", "mode.release")
@@ -20,7 +25,7 @@ end
 
 target("client")
     set_kind("shared")
-    if force_msvc == true then
+    if is_os("windows") and force_msvc == true then
         set_toolchains("msvc")
     end
     set_basename("CoopAndreasSA")
@@ -131,12 +136,13 @@ target("server")
         add_defines("_CRT_SECURE_NO_WARNINGS", "WIN32", "_CONSOLE")
 
     elseif is_os("linux") then
-        -- TODO
+        set_toolchains("gcc", "clang")
+        add_syslinks("pthread")
     end
 
 target("proxy")
     set_kind("shared")
-    if force_msvc == true then
+    if is_os("windows") and force_msvc == true then
         set_toolchains("msvc")
     end
     set_arch("x86")


### PR DESCRIPTION
WARNING: THIS COMMIT WAS ENTIRELY MADE BY AI. I do not understand either C++ or the logic of this code enough to fix this myself.

In short, else than some modifications to xmake.lua, this commit seems to add Linux-specific functions to replace strcpy_s and _strcicmp, which were preventing compilation. The finished executable, on a surface level, seems to work. Compiling for Windows after this change has not been tested (since i don't have Windows or VS2022).