### PR TITLE
Fix 0x4D68BA crash

### DIFF
--- a/client/src/CNetworkPed.cpp
+++ b/client/src/CNetworkPed.cpp
@@ -52,6 +52,7 @@ CNetworkPed::CNetworkPed(int pedid, int modelId, ePedType pedType, CVector pos, 
         m_pPed = new CCivilianPed(pedType, modelId);
     }
 
+    m_nPedPoolRef = CPools::GetPedRef(m_pPed);
     m_pPed->m_nCreatedBy = 2;
     m_pPed->m_pIntelligence->SetPedDecisionMakerType(-1);
     m_pPed->m_pIntelligence->SetSeeingRange(30.0);
@@ -67,62 +68,84 @@ CNetworkPed::CNetworkPed(int pedid, int modelId, ePedType pedType, CVector pos, 
     m_nPedType = pedType;
     m_bSyncing = false;
     m_nCreatedBy = createdBy;
-
-    // THIS IS AN EXPERIMENTAL SOLUTION FOR THE 0x4D68BA CRASH
-    m_pPed->m_bStreamingDontDelete = true;
 }
 
 CNetworkPed::~CNetworkPed()
 {
+    CPed* pPed = HasValidPed() ? m_pPed : nullptr;
+    int nPedPoolRef = m_nPedPoolRef;
+    DetachPed();
+
     if (m_bSyncing)
     {
-        Packets::Peds::PedRemove packet{};
-        packet.pedid = m_nPedId;
-        GetPacketFactory().Send(packet);
+        if (m_nPedId >= 0)
+        {
+            Packets::Peds::PedRemove packet{};
+            packet.pedid = m_nPedId;
+            GetPacketFactory().Send(packet);
+        }
     }
     else
     {
-
-        if (m_pPed && m_pPed->m_matrix->m_pOwner)
+        if (pPed && pPed->m_matrix && pPed->m_matrix->m_pOwner)
         {
             if (m_nBlipHandle != -1)
             {
-                CRadar::ClearBlipForEntity(eBlipType::BLIP_CHAR, CPools::GetPedRef(m_pPed));
+                CRadar::ClearBlipForEntity(eBlipType::BLIP_CHAR, nPedPoolRef);
                 //CChat::AddMessage("REMOVE THE FUCKING BLIP");
             }
 
-            if (m_pPed->m_nPedFlags.bInVehicle)
+            if (pPed->m_nPedFlags.bInVehicle)
             {
-                plugin::Command<Commands::WARP_CHAR_FROM_CAR_TO_COORD>(CPools::GetPedRef(m_pPed), 0.f, 0.f, 0.f);
+                plugin::Command<Commands::WARP_CHAR_FROM_CAR_TO_COORD>(nPedPoolRef, 0.f, 0.f, 0.f);
             }
 
-            CWorld::Remove(m_pPed);
-            //CWorld::RemoveReferencesToDeletedObject(m_pPed);
-            m_pPed->Remove();
-            delete m_pPed;
+            CWorld::Remove(pPed);
+            //CWorld::RemoveReferencesToDeletedObject(pPed);
+            pPed->Remove();
+            delete pPed;
         }
     }
 }
 
-CNetworkPed* CNetworkPed::CreateHosted(CPed* ped)
+bool CNetworkPed::HasValidPed() const
 {
-    ped->field_54C += 5000; // m_nTimeTillWeNeedThisPed
+    return m_pPed && m_nPedPoolRef >= 0 && CPools::ms_pPedPool && CPools::GetPed(m_nPedPoolRef) == m_pPed;
+}
 
-    CNetworkPed* networkPed = new CNetworkPed();
+void CNetworkPed::DetachPed()
+{
+    m_pPed = nullptr;
+    m_nPedPoolRef = -1;
+}
 
-    networkPed->m_pPed = ped;
-    networkPed->m_nPedId = 0;
-    networkPed->m_nCreatedBy = ped->m_nCreatedBy;
-    networkPed->m_bSyncing = true;
-    networkPed->m_nTempId = CNetworkPedManager::AddToTempList(networkPed);
+CNetworkPed* CNetworkPed::CreateHosted(CPed* pPed)
+{
+    CNetworkPed* pNetworkPed = new CNetworkPed();
+
+    pNetworkPed->m_pPed = pPed;
+    pNetworkPed->m_nPedPoolRef = CPools::GetPedRef(pPed);
+    pNetworkPed->m_nPedId = -1;
+    pNetworkPed->m_nCreatedBy = pPed->m_nCreatedBy;
+    pNetworkPed->m_bSyncing = true;
+    pNetworkPed->m_nTempId = CNetworkPedManager::AddToTempList(pNetworkPed);
+
+    if (pNetworkPed->m_nTempId == 255)
+    {
+        pNetworkPed->DetachPed();
+        delete pNetworkPed;
+        return nullptr;
+    }
+
+    pPed->field_54C += 5000; // m_nTimeTillWeNeedThisPed
 
     Packets::Peds::PedSpawn packet{};
-    packet.tempid = networkPed->m_nTempId;
-    packet.pedid = networkPed->m_nPedId;
-    packet.modelId = static_cast<eModelID>(ped->m_nModelIndex);
-    packet.pos = ped->m_matrix->pos;
-    packet.pedType = static_cast<ePedType>(ped->m_nPedType);
-    packet.createdBy = static_cast<eCharCreatedBy>(ped->m_nCreatedBy);
+    packet.tempid = pNetworkPed->m_nTempId;
+    packet.pedid = 0; // the server assigns the real id before forwarding the spawn
+    packet.modelId = static_cast<eModelID>(pPed->m_nModelIndex);
+    packet.pos = pPed->m_matrix->pos;
+    packet.pedType = static_cast<ePedType>(pPed->m_nPedType);
+    packet.createdBy = static_cast<eCharCreatedBy>(pPed->m_nCreatedBy);
 
     if (packet.modelId >= MODEL_SPECIAL01 && packet.modelId <= MODEL_SPECIAL10)
     {
@@ -131,7 +154,7 @@ CNetworkPed* CNetworkPed::CreateHosted(CPed* ped)
     }
     GetPacketFactory().Send(packet);
 
-    return networkPed;
+    return pNetworkPed;
 }
 
 void CNetworkPed::WarpIntoVehicleDriver(CVehicle* vehicle)

--- a/client/src/CNetworkPed.h
+++ b/client/src/CNetworkPed.h
@@ -6,6 +6,7 @@ private:
 public:
 	int m_nPedId = -1;
 	CPed* m_pPed = nullptr;
+	int m_nPedPoolRef = -1;
 	bool m_bSyncing = false;
 	unsigned char m_nTempId = 255;
 	ePedType m_nPedType;
@@ -24,7 +25,9 @@ public:
 	int m_nBlipHandle = -1;
 	bool m_bClaimOnRelease = false;
 
-	static CNetworkPed* CreateHosted(CPed* ped);
+	static CNetworkPed* CreateHosted(CPed* pPed);
+	bool HasValidPed() const;
+	void DetachPed();
 	void WarpIntoVehicleDriver(CVehicle* vehicle);
 	void WarpIntoVehiclePassenger(CVehicle* vehicle, int seatid);
 	void RemoveFromVehicle(CVehicle* vehicle);

--- a/client/src/CNetworkPedManager.cpp
+++ b/client/src/CNetworkPedManager.cpp
@@ -9,7 +9,7 @@ CNetworkPed* CNetworkPedManager::GetPed(int pedid)
 {
     for (int i = 0; i != m_pPeds.size(); i++)
     {
-        if (m_pPeds[i]->m_nPedId == pedid)
+        if (m_pPeds[i]->m_nPedId == pedid && m_pPeds[i]->HasValidPed())
         {
             return m_pPeds[i];
         }
@@ -24,13 +24,33 @@ CNetworkPed* CNetworkPedManager::GetPed(CEntity* entity)
 
     for (int i = 0; i != m_pPeds.size(); i++)
     {
-        if (m_pPeds[i]->m_pPed == entity)
+        if (m_pPeds[i]->m_pPed == entity && m_pPeds[i]->HasValidPed())
         {
             return m_pPeds[i];
         }
     }
 
     return nullptr;
+}
+
+bool CNetworkPedManager::IsPedTracked(CPed* pPed)
+{
+    if (!pPed)
+        return false;
+
+    for (CNetworkPed* pNetworkPed : m_pPeds)
+    {
+        if (pNetworkPed && pNetworkPed->m_pPed == pPed && pNetworkPed->HasValidPed())
+            return true;
+    }
+
+    for (CNetworkPed* pNetworkPed : m_apTempPeds)
+    {
+        if (pNetworkPed && pNetworkPed->m_pPed == pPed && pNetworkPed->HasValidPed())
+            return true;
+    }
+
+    return false;
 }
 
 void CNetworkPedManager::Add(CNetworkPed* ped)
@@ -47,9 +67,40 @@ void CNetworkPedManager::Remove(CNetworkPed* ped)
     }
 }
 
+void CNetworkPedManager::HandlePedDestruction(CPed* pPed)
+{
+    if (!pPed)
+        return;
+
+    // At the native destructor boundary, every wrapper retaining this address is stale,
+    // including wrappers from earlier pool generations.
+    for (auto it = m_pPeds.begin(); it != m_pPeds.end();)
+    {
+        CNetworkPed* pNetworkPed = *it;
+        if (!pNetworkPed || pNetworkPed->m_pPed != pPed)
+        {
+            ++it;
+            continue;
+        }
+
+        pNetworkPed->CancelClaim();
+        pNetworkPed->DetachPed();
+        it = m_pPeds.erase(it);
+        delete pNetworkPed;
+    }
+
+    for (CNetworkPed* pNetworkPed : m_apTempPeds)
+    {
+        if (!pNetworkPed || pNetworkPed->m_pPed != pPed)
+            continue;
+
+        pNetworkPed->DetachPed();
+    }
+}
+
 void CNetworkPedManager::Update()
 {
-    CNetworkPedManager::RemoveHostedUnused();
+    CNetworkPedManager::RemoveInvalidPeds();
 
     for (CNetworkPed* pNetworkPed : m_pPeds)
     {
@@ -193,6 +244,9 @@ void CNetworkPedManager::Process()
 {
     for (auto networkPed : m_pPeds)
     {
+        if (!networkPed->HasValidPed())
+            continue;
+
         if (networkPed->m_bSyncing)
             continue;
 
@@ -240,20 +294,27 @@ unsigned char CNetworkPedManager::AddToTempList(CNetworkPed* networkPed)
     return 255;
 }
 
-void CNetworkPedManager::RemoveHostedUnused()
+void CNetworkPedManager::RemoveInvalidPeds()
 {
     for (auto it = CNetworkPedManager::m_pPeds.begin(); it != CNetworkPedManager::m_pPeds.end();)
     {
-        if ((*it)->m_bSyncing)
+        CNetworkPed* pNetworkPed = *it;
+        if (!pNetworkPed->HasValidPed())
         {
-            CPed* ped = (*it)->m_pPed;
-            if (!IsPedPointerValid(ped))
-            {
-                delete *it;
-                it = m_pPeds.erase(it);
-                continue;
-            }
+            pNetworkPed->CancelClaim();
+            pNetworkPed->DetachPed();
+            it = m_pPeds.erase(it);
+            delete pNetworkPed;
+            continue;
         }
         ++it;
+    }
+
+    for (CNetworkPed* pNetworkPed : m_apTempPeds)
+    {
+        if (!pNetworkPed || !pNetworkPed->m_pPed || pNetworkPed->HasValidPed())
+            continue;
+
+        pNetworkPed->DetachPed();
     }
 }

--- a/client/src/CNetworkPedManager.h
+++ b/client/src/CNetworkPedManager.h
@@ -7,12 +7,14 @@ public:
 
 	static CNetworkPed* GetPed(int pedid);
 	static CNetworkPed* GetPed(CEntity* entity);
+	static bool IsPedTracked(CPed* pPed);
 	static void Add(CNetworkPed* ped);
 	static void Remove(CNetworkPed* ped);
+	static void HandlePedDestruction(CPed* pPed);
 	static void Update();
 	static void Process();
 	static void AssignHost();
 	static unsigned char AddToTempList(CNetworkPed* networkPed);
-	static void RemoveHostedUnused();
+	static void RemoveInvalidPeds();
 };
 

--- a/client/src/CNetworkPlayer.cpp
+++ b/client/src/CNetworkPlayer.cpp
@@ -42,9 +42,6 @@ void CNetworkPlayer::CreatePed(int id, CVector position)
     *m_pPed->m_pPlayerData->m_pPedClothesDesc = m_pPedClothesDesc;
 
     CClothes::RebuildPlayer(m_pPed, false);
-
-    // THIS IS AN EXPERIMENTAL SOLUTION FOR THE 0x4D68BA CRASH
-    m_pPed->m_bStreamingDontDelete = true;
 }
 
 void CNetworkPlayer::DestroyPed()

--- a/client/src/Hooks/WorldHooks.cpp
+++ b/client/src/Hooks/WorldHooks.cpp
@@ -90,11 +90,11 @@ static void __cdecl CWorld__Add_Hook(CEntity* entity)
         }
         else if (entity->m_nType == eEntityType::ENTITY_TYPE_PED)
         {
-            CPed* ped = (CPed*)entity;
+            CPed* pPed = static_cast<CPed*>(entity);
 
-            if (ped->m_nPedType > 1)
+            if (pPed->m_nPedType > 1 && !CNetworkPedManager::IsPedTracked(pPed))
             {
-                CNetworkPed* networkPed = CNetworkPed::CreateHosted(ped);
+                CNetworkPed::CreateHosted(pPed);
             }
         }
     }
@@ -114,24 +114,17 @@ static void __cdecl CWorld__Remove_Hook(CEntity* entity)
             delete networkVehicle;
         }
     }
-    else if (entity->m_nType == eEntityType::ENTITY_TYPE_PED)
-    {
-        CPed* ped = (CPed*)entity;
-        if (ped->m_nPedType > 3)
-        {
-            CNetworkPed* networkPed = CNetworkPedManager::GetPed(ped);
-            if (networkPed && networkPed->m_bSyncing)
-            {
-                CNetworkPedManager::Remove(networkPed);
-                delete networkPed;
-            }
-        }
-    }
-
     if (entity && (unsigned int)*(void***)entity != 0x863C40)
     {
         CWorld::Remove(entity);
     }
+}
+
+static void __cdecl CWorld__RemovePedDestructor_Hook(CPed* pPed)
+{
+    // CPed::~CPed still owns its pool slot here. Detach every wrapper before that slot can be reused.
+    CNetworkPedManager::HandlePedDestruction(pPed);
+    CWorld__Remove_Hook(pPed);
 }
 
 static bool __fastcall CEntryExit__TransitionStarted_Hook(CEntryExit* This, SKIP_EDX, CPed* ped)
@@ -295,12 +288,13 @@ void WorldHooks::InjectHooks()
         0x456E1E, 0x456EA0, 0x4571AD, 0x458E8A, 0x45BEFF, 0x45CCB5, 0x45D3C9, 0x45D3FE, 0x45ED11, 0x45ED69, 0x45FF78,
         0x45FFCB, 0x4610CC, 0x4698E4, 0x467B3C, 0x486D3E, 0x499D90, 0x49A45A, 0x53C98C, 0x5500C5, 0x5567CE, 0x5667B0,
         0x59163E, 0x593794, 0x5A1890, 0x5A18EA, 0x5A194E, 0x5A1A51, 0x5A32A2, 0x5A3FE2, 0x5AFE6E, 0x5D5112, 0x5E011C,
-        0x5E03DC, 0x5E86AF, 0x6094FC, 0x610F26, 0x612305, 0x612F1A, 0x615EA6, 0x615F2D, 0x616404, 0x61AEE3, 0x61AF07,
+        0x5E03DC, 0x6094FC, 0x610F26, 0x612305, 0x612F1A, 0x615EA6, 0x615F2D, 0x616404, 0x61AEE3, 0x61AF07,
         0x6C7B9A, 0x6CCCB2, 0x6D22D7, 0x6E3E7D, 0x6E3FFD, 0x6E4120, 0x6E51B4, 0x6F5DD7, 0x6F6A7B, 0x6F6B31, 0x6F7ACA,
         0x717897, 0x738AFF, 0x73997A, 0x739A17, 0x739AD0};
     patch::RedirectCall(
         std::vector<int>(CWorld__Remove_Addresses, CWorld__Remove_Addresses + sizeof(CWorld__Remove_Addresses) / 4),
         CWorld__Remove_Hook);
+    patch::RedirectCall(0x5E86AF, CWorld__RemovePedDestructor_Hook);
 
     // patch::RedirectJump(0x47D43E, CWeather__ForceWeather_Hook);
     // patch::RedirectJump(0x72A4F0, CWeather__ForceWeatherNow_Hook);

--- a/client/src/PacketHandlers/peds.cpp
+++ b/client/src/PacketHandlers/peds.cpp
@@ -29,8 +29,16 @@ PACKET_HANDLER(ePacketType::PED_CONFIRM, Packets::Peds::PedConfirm* pPedConfirm)
         if (pTempPed)
         {
             pTempPed->m_nPedId = pPedConfirm->pedid;
-            CNetworkPedManager::Add(pTempPed);
             CNetworkPedManager::m_apTempPeds[pPedConfirm->tempid] = nullptr;
+
+            if (!pTempPed->HasValidPed())
+            {
+                delete pTempPed;
+            }
+            else
+            {
+                CNetworkPedManager::Add(pTempPed);
+            }
         }
     }
 }
@@ -55,6 +63,11 @@ PACKET_HANDLER(ePacketType::ASSIGN_PED, Packets::Peds::AssignPedSyncer* pAssignP
 
     if (!pNetworkPed)
     {
+        // A claim cancellation can race the owner's removal. If the server already assigned
+        // the missing ped to us, this removal is accepted; otherwise the server ignores it.
+        Packets::Peds::PedRemove pedRemovePacket{};
+        pedRemovePacket.pedid = pAssignPedSyncer->pedid;
+        GetPacketFactory().Send(pedRemovePacket);
         return;
     }
 


### PR DESCRIPTION
Reproduction on an unpatched build

1. Start a two-player session with Player 1 as host.
2. Place both players near the same interior entrance.
3. Give Player 1 a two-star wanted level.
4. Wait for several police officers to surround the players and begin aiming or shooting.
5. Repeatedly enter and exit the interior, alternating between both players.
6. Keep one player outside with the police while the other transitions.
7. Continue when police officers disappear for one client but remain active for the other.

The crash is timing-dependent, so the transitions may need to be repeated for several minutes.

Expected result: one client crashes with exception `0xC0000005` at module offset `0x000D68BA`, corresponding to GTA address `0x004D68BA`.